### PR TITLE
Enthusiastic rule effect does not match the description

### DIFF
--- a/src/assets/XenosRampantData/units.ts
+++ b/src/assets/XenosRampantData/units.ts
@@ -171,7 +171,7 @@ export const unitsData: Units = {
         description:
           "This unit's Attack Value is reduced by 1 (e.g. 4+ to 5+ for base units).",
         adjustStats: {
-          attackValue: -1,
+          attackValue: +1,
         },
       },
       'Heavy Armor': {


### PR DESCRIPTION
Noticed while playing around that ```Enthusiastic but untrained``` has the opposite effect to that described, in that it actually makes the unit's attack value better instead of worse.