### PR TITLE
Correct Close Quarters Doctrine

### DIFF
--- a/src/assets/XenosRampantData/unitOptions.ts
+++ b/src/assets/XenosRampantData/unitOptions.ts
@@ -65,7 +65,6 @@ export const unitOptions: UnitOptions = {
     description:
       'This unit is armed for short-range combat, reducing its Shooting Range to 12".',
     setStats: {
-      shootValue: 4,
       shootRange: 12,
     },
     disabledBy: ['Artillery'],


### PR DESCRIPTION
The rule was changing the unit's shoot value to 4+, irrespective of type, which is not correct for the rule option; it only reduces the shoot range to 12".