### PR TITLE
fix: remove negation from isPsycher definition

### DIFF
--- a/src/components/Validation.tsx
+++ b/src/components/Validation.tsx
@@ -19,7 +19,7 @@ const Validation = () => {
 
   const warnings = [];
   for (const unit of units) {
-    const isPsycher = !unit.xenosRules.some((x) =>
+    const isPsycher = unit.xenosRules.some((x) =>
       ['Psychic 1', 'Psychic 2', 'Psychic 3', 'Psychic 4'].includes(x)
     );
     if (unit.points > 12)


### PR DESCRIPTION
Fixes #5 by removing the negation from the definition of `isPsycher` in Validation.tsx.